### PR TITLE
Add tests for events fired at <body> & <html>

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@ html,body {
 <li><a href="./tests/event-listener-body.html">event listener - events fired at &lt;body&gt;</a></li>
 <li><a href="./tests/event-listener-body-clickable.html">event listener - events fired at &lt;body&gt; - with iOS clickability hacks</a></li>
 <li><a href="./tests/event-listener-html.html">event listener - events fired at &lt;html&gt;</a></li>
+<li><a href="./tests/event-listener-html-clickable.html">event listener - events fired at &lt;html&gt; - with iOS clickability hacks</a></li>
 </ul>
 
 <ul>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@ html,body {
 <li><a href="./tests/event-listener_touch-action-manipulation_no-meta.html">event listener - touch-action:manipulation - no meta viewport</a></li>
 <li><a href="./tests/event-listener-pointer-over-enter-out-leave.html">event listener - pointer over/enter/out/leave</a></li>
 <li><a href="./tests/event-listener-body.html">event listener - events fired at &lt;body&gt;</a></li>
+<li><a href="./tests/event-listener-body-clickable.html">event listener - events fired at &lt;body&gt; - with iOS clickability hacks</a></li>
 </ul>
 
 <ul>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@ html,body {
 <li><a href="./tests/event-listener-pointer-over-enter-out-leave.html">event listener - pointer over/enter/out/leave</a></li>
 <li><a href="./tests/event-listener-body.html">event listener - events fired at &lt;body&gt;</a></li>
 <li><a href="./tests/event-listener-body-clickable.html">event listener - events fired at &lt;body&gt; - with iOS clickability hacks</a></li>
+<li><a href="./tests/event-listener-html.html">event listener - events fired at &lt;html&gt;</a></li>
 </ul>
 
 <ul>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@ html,body {
 <li><a href="./tests/event-listener_touch-action-manipulation.html">event listener - touch-action:manipulation</a></li>
 <li><a href="./tests/event-listener_touch-action-manipulation_no-meta.html">event listener - touch-action:manipulation - no meta viewport</a></li>
 <li><a href="./tests/event-listener-pointer-over-enter-out-leave.html">event listener - pointer over/enter/out/leave</a></li>
+<li><a href="./tests/event-listener-body.html">event listener - events fired at &lt;body&gt;</a></li>
 </ul>
 
 <ul>

--- a/tests/event-listener-body-clickable.html
+++ b/tests/event-listener-body-clickable.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html onclick="void(0)">
+<head>
+<meta charset="utf-8">
+<title>Event listener for event on &lt;body&gt;, with iOS clickability hacks</title>
+<meta name="viewport" content="width=device-width">
+<link rel="stylesheet" href="style.css">
+<style>
+html {
+	margin: 0;
+}
+body {
+	margin: 0;
+	background-color: #5290ba;
+	cursor: pointer;
+}
+h1, p {
+	background-color: #eee;
+	padding-left: 8px;
+}
+h1 {
+	margin-bottom: 0;
+}
+p {
+	margin-top: 0;
+	margin-bottom: 0;
+	border-width: 1em 0 0 0;
+	border-color: #eee;
+	border-style: solid;
+}
+.i {
+	margin-bottom: 4rem !important;
+}
+</style>
+<script>
+window.addEventListener('load', function() {
+	var events = [
+	'mouseover',
+	// 'mousemove', // Fires annoyingly frequently on desktop, cluttering the results
+	'mouseout',
+	'mouseenter',
+	'mouseleave',
+	'mousedown',
+	'mouseup',
+	'focus',
+	'blur',
+	'click',
+	'MSPointerDown',
+	'MSPointerUp',
+	'MSPointerCancel',
+	'MSPointerMove',
+	'MSPointerOver',
+	'MSPointerOut',
+	'MSPointerEnter',
+	'MSPointerLeave',
+	'MSGotPointerCapture',
+	'MSLostPointerCapture',
+	'pointerdown',
+	'pointerup',
+	'pointercancel',
+	'pointermove',
+	'pointerover',
+	'pointerout',
+	'pointerenter',
+	'pointerleave',
+	'gotpointercapture',
+	'lostpointercapture',
+	'touchstart',
+	'touchmove',
+	'touchend',
+	'touchenter',
+	'touchleave',
+	'touchcancel'	
+	];
+	var body = document.getElementsByTagName('body')[0];
+	var o = document.getElementById('o');
+	var report = function(e) {
+		if (e.eventPhase === Event.AT_TARGET) {
+			var s = e.type + '<br>';
+			setTimeout(function() { delayedInnerHTML(s) }, 100);
+		}
+	};
+
+	/* Hack to work around new iOS8 behavior where innerHTML counts as a content change - previously, it was safe to use, see http://www.quirksmode.org/blog/archives/2014/02/the_ios_event_c.html */
+	delayedInnerHTML = function(s) {
+		o.innerHTML += s;
+	}
+
+	for (var i=0; i<events.length; i++) {
+		body.addEventListener(events[i], report, false);
+	}
+}, false);
+</script>
+</head>
+<body onclick="void(0)">
+<h1>Event listener</h1>
+<p>Test to see what events the <code>&lt;body&gt;</code> itself fires.</p>
+<p>Tries to coax iOS Safari into firing clicks by applying the <code>onclick="void(0)"</code> and <code>cursor:pointer</code> hacks.</p>
+<p class="i">Tap or click within the blue area below this text.</p>
+<p>Events (other than <code>mousemove</code>) targeted at the <code>&lt;body&gt;</code> element:</p>
+<output id="o"></output>
+</body>
+</html>

--- a/tests/event-listener-body.html
+++ b/tests/event-listener-body.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Event listener for event on &lt;body&gt;</title>
+<meta name="viewport" content="width=device-width">
+<link rel="stylesheet" href="style.css">
+<style>
+html {
+	margin: 0;
+}
+body {
+	margin: 0;
+	background-color: #5290ba;
+}
+h1, p {
+	background-color: #eee;
+	padding-left: 8px;
+}
+h1 {
+	margin-bottom: 0;
+}
+p {
+	margin-top: 0;
+	margin-bottom: 0;
+	border-width: 1em 0 0 0;
+	border-color: #eee;
+	border-style: solid;
+}
+.i {
+	margin-bottom: 4rem !important;
+}
+</style>
+<script>
+window.addEventListener('load', function() {
+	var events = [
+	'mouseover',
+	// 'mousemove', // Fires annoyingly frequently on desktop, cluttering the results
+	'mouseout',
+	'mouseenter',
+	'mouseleave',
+	'mousedown',
+	'mouseup',
+	'focus',
+	'blur',
+	'click',
+	'MSPointerDown',
+	'MSPointerUp',
+	'MSPointerCancel',
+	'MSPointerMove',
+	'MSPointerOver',
+	'MSPointerOut',
+	'MSPointerEnter',
+	'MSPointerLeave',
+	'MSGotPointerCapture',
+	'MSLostPointerCapture',
+	'pointerdown',
+	'pointerup',
+	'pointercancel',
+	'pointermove',
+	'pointerover',
+	'pointerout',
+	'pointerenter',
+	'pointerleave',
+	'gotpointercapture',
+	'lostpointercapture',
+	'touchstart',
+	'touchmove',
+	'touchend',
+	'touchenter',
+	'touchleave',
+	'touchcancel'	
+	];
+	var body = document.getElementsByTagName('body')[0];
+	var o = document.getElementById('o');
+	var report = function(e) {
+		if (e.eventPhase === Event.AT_TARGET) {
+			var s = e.type + '<br>';
+			setTimeout(function() { delayedInnerHTML(s) }, 100);
+		}
+	};
+
+	/* Hack to work around new iOS8 behavior where innerHTML counts as a content change - previously, it was safe to use, see http://www.quirksmode.org/blog/archives/2014/02/the_ios_event_c.html */
+	delayedInnerHTML = function(s) {
+		o.innerHTML += s;
+	}
+
+	for (var i=0; i<events.length; i++) {
+		body.addEventListener(events[i], report, false);
+	}
+}, false);
+</script>
+</head>
+<body>
+<h1>Event listener</h1>
+<p>Test to see what events the <code>&lt;body&gt;</code> itself fires.</p>
+<p class="i">Tap or click within the blue area below this text.</p>
+<p>Events (other than <code>mousemove</code>) targeted at the <code>&lt;body&gt;</code> element:</p>
+<output id="o"></output>
+</body>
+</html>

--- a/tests/event-listener-html-clickable.html
+++ b/tests/event-listener-html-clickable.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html onclick="void(0)">
+<head>
+<meta charset="utf-8">
+<title>Event listener for event on &lt;html&gt;, with iOS clickability hacks</title>
+<meta name="viewport" content="width=device-width">
+<link rel="stylesheet" href="style.css">
+<style>
+html {
+	margin: 0;
+	background-color: #5290ba;
+	cursor: pointer;
+}
+body {
+	height: 0;
+	margin: 0;
+}
+h1, p {
+	background-color: #eee;
+	padding-left: 8px;
+	margin-top: 0;
+	margin-bottom: 0;
+	border-width: 1em 0 0 0;
+	border-color: #eee;
+	border-style: solid;
+}
+.i {
+	margin-bottom: 4rem !important;
+}
+</style>
+<script>
+window.addEventListener('load', function() {
+	var events = [
+	'mouseover',
+	// 'mousemove', // Fires annoyingly frequently on desktop, cluttering the results
+	'mouseout',
+	'mouseenter',
+	'mouseleave',
+	'mousedown',
+	'mouseup',
+	'focus',
+	'blur',
+	'click',
+	'MSPointerDown',
+	'MSPointerUp',
+	'MSPointerCancel',
+	'MSPointerMove',
+	'MSPointerOver',
+	'MSPointerOut',
+	'MSPointerEnter',
+	'MSPointerLeave',
+	'MSGotPointerCapture',
+	'MSLostPointerCapture',
+	'pointerdown',
+	'pointerup',
+	'pointercancel',
+	'pointermove',
+	'pointerover',
+	'pointerout',
+	'pointerenter',
+	'pointerleave',
+	'gotpointercapture',
+	'lostpointercapture',
+	'touchstart',
+	'touchmove',
+	'touchend',
+	'touchenter',
+	'touchleave',
+	'touchcancel'	
+	];
+	var h = document.getElementsByTagName('html')[0];
+	var o = document.getElementById('o');
+	var report = function(e) {
+		if (e.eventPhase === Event.AT_TARGET) {
+			var s = e.type + '<br>';
+			setTimeout(function() { delayedInnerHTML(s) }, 100);
+		}
+	};
+
+	/* Hack to work around new iOS8 behavior where innerHTML counts as a content change - previously, it was safe to use, see http://www.quirksmode.org/blog/archives/2014/02/the_ios_event_c.html */
+	delayedInnerHTML = function(s) {
+		o.innerHTML += s;
+	}
+
+	for (var i=0; i<events.length; i++) {
+		h.addEventListener(events[i], report, false);
+	}
+}, false);
+</script>
+</head>
+<body>
+<h1>Event listener</h1>
+<p>Test to see what events the <code>&lt;html&gt;</code> itself fires.</p>
+<p>Tries to coax iOS Safari into firing clicks by applying the <code>onclick="void(0)"</code> and <code>cursor:pointer</code> hacks.</p>
+<p class="i">Tap or click the blue area below this text.</p>
+<p>Events (other than <code>mousemove</code>) targeted at the <code>&lt;html&gt;</code> element:</p>
+<output id="o"></output>
+</body>
+</html>

--- a/tests/event-listener-html.html
+++ b/tests/event-listener-html.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Event listener for event on &lt;html&gt;</title>
+<meta name="viewport" content="width=device-width">
+<link rel="stylesheet" href="style.css">
+<style>
+html {
+	margin: 0;
+	background-color: #5290ba;
+}
+body {
+	height: 0;
+	margin: 0;
+}
+h1, p {
+	background-color: #eee;
+	padding-left: 8px;
+	margin-top: 0;
+	margin-bottom: 0;
+	border-width: 1em 0 0 0;
+	border-color: #eee;
+	border-style: solid;
+}
+.i {
+	margin-bottom: 4rem !important;
+}
+</style>
+<script>
+window.addEventListener('load', function() {
+	var events = [
+	'mouseover',
+	// 'mousemove', // Fires annoyingly frequently on desktop, cluttering the results
+	'mouseout',
+	'mouseenter',
+	'mouseleave',
+	'mousedown',
+	'mouseup',
+	'focus',
+	'blur',
+	'click',
+	'MSPointerDown',
+	'MSPointerUp',
+	'MSPointerCancel',
+	'MSPointerMove',
+	'MSPointerOver',
+	'MSPointerOut',
+	'MSPointerEnter',
+	'MSPointerLeave',
+	'MSGotPointerCapture',
+	'MSLostPointerCapture',
+	'pointerdown',
+	'pointerup',
+	'pointercancel',
+	'pointermove',
+	'pointerover',
+	'pointerout',
+	'pointerenter',
+	'pointerleave',
+	'gotpointercapture',
+	'lostpointercapture',
+	'touchstart',
+	'touchmove',
+	'touchend',
+	'touchenter',
+	'touchleave',
+	'touchcancel'	
+	];
+	var h = document.getElementsByTagName('html')[0];
+	var o = document.getElementById('o');
+	var report = function(e) {
+		if (e.eventPhase === Event.AT_TARGET) {
+			var s = e.type + '<br>';
+			setTimeout(function() { delayedInnerHTML(s) }, 100);
+		}
+	};
+
+	/* Hack to work around new iOS8 behavior where innerHTML counts as a content change - previously, it was safe to use, see http://www.quirksmode.org/blog/archives/2014/02/the_ios_event_c.html */
+	delayedInnerHTML = function(s) {
+		o.innerHTML += s;
+	}
+
+	for (var i=0; i<events.length; i++) {
+		h.addEventListener(events[i], report, false);
+	}
+}, false);
+</script>
+</head>
+<body>
+<h1>Event listener</h1>
+<p>Test to see what events the <code>&lt;html&gt;</code> itself fires.</p>
+<p class="i">Tap or click the blue area below this text.</p>
+<p>Events (other than <code>mousemove</code>) targeted at the <code>&lt;html&gt;</code> element:</p>
+<output id="o"></output>
+</body>
+</html>


### PR DESCRIPTION
This is blocked on #9.

This adds tests for events fired at the `<body>` element.
Why this is interesting: Less formal experiments suggest that iOS Safari doesn't fire click events when the `<body>` is tapped. Such click events would be useful for e.g. dismissing tooltips.
