### PR TITLE
Report event.detail for 'click' event

### DIFF
--- a/tests/report.js
+++ b/tests/report.js
@@ -51,6 +51,9 @@ window.addEventListener('load', function() {
 		var delta = now-t;
 		var s;
 		s = e.type;
+                if (e.type == 'click') {
+                        s += ' (detail=' + (e.detail) + ')';
+                }
 		if (t>0) {
 			if ((now-t)>150) {
 				s += ' (<strong>' + (delta) + 'ms</strong>)';


### PR DESCRIPTION
`event.detail` is often overlooked because it's defined in `UIEvent` while actually it's only relevant to `MouseEvent`.

It would be useful to see this aspect of default browser behaviour.

